### PR TITLE
Slowdown scan time a bit to improve reliability

### DIFF
--- a/task/keys.c
+++ b/task/keys.c
@@ -356,7 +356,7 @@ static void HandlerLong(KEY_t Key)
 				RADIO_CancelMode();
 				gScannerMode = !gScannerMode;
 				bBeep740 = gScannerMode;
-				SCANNER_Countdown = 25;
+				SCANNER_Countdown = 50;
 				break;
 
 			case KEY_2:

--- a/task/scanner.c
+++ b/task/scanner.c
@@ -36,7 +36,7 @@ void Task_Scanner(void)
 			CHANNELS_NextChannelVfo(gSettings.ScanDirection ? KEY_DOWN : KEY_UP);
 			RADIO_Tune(gSettings.CurrentVfo);
 		}
-		SCANNER_Countdown = 25;
+		SCANNER_Countdown = 50;
 		gpio_bits_flip(GPIOA, BOARD_GPIOA_LED_GREEN);
 	}
 }


### PR DESCRIPTION
Increasing SCANNER_Countdown to 50 seems much more reliable without being significantly slower.