### PR TITLE
Fix frequency detector keys #26

### DIFF
--- a/task/keyaction.c
+++ b/task/keyaction.c
@@ -123,6 +123,7 @@ void KeypressAction(uint8_t Action) {
 			case ACTION_FREQUENCY_DETECT:
 				if (!gSettings.bFLock) {
 					gInputBoxWriteIndex = 0;
+					KEY_LongPressed = false;
 					RADIO_FrequencyDetect();
 				}
 				break;


### PR DESCRIPTION
* and # keys not working when detector launched from digit key