### PR TITLE
Improved squelch logic

### DIFF
--- a/radio/frequencies.c
+++ b/radio/frequencies.c
@@ -24,10 +24,6 @@ uint8_t gCurrentFrequencyBand = 0xFF;
 
 uint8_t gTxPowerLevelHigh = 40;
 uint8_t gTxPowerLevelLow = 20;
-uint8_t gSquelchNoiseWide = 40;
-uint8_t gSquelchNoiseNarrow = 40;
-uint8_t gSquelchRSSIWide = 80;
-uint8_t gSquelchRSSINarrow = 85;
 
 uint32_t FREQUENCY_GetStep(uint8_t StepSetting)
 {
@@ -96,15 +92,7 @@ void FREQUENCY_SelectBand(uint32_t Frequency)
 		Level = 15;
 	}
 
-	gSquelchNoiseWide = gFrequencyBandInfo.SquelchNoiseWide[Level];
-	gSquelchRSSIWide = gFrequencyBandInfo.SquelchRSSIWide[Level];
-	if (Band == BAND_64MHz) {
-		gSquelchNoiseWide += 10;
-		gSquelchRSSIWide -= 10;
-	}
 	gTxPowerLevelLow = gFrequencyBandInfo.TxPowerLevelLow[Level];
 	gTxPowerLevelHigh = gFrequencyBandInfo.TxPowerLevelHigh[Level];
-	gSquelchNoiseNarrow = gFrequencyBandInfo.SquelchNoiseNarrow[Level];
-	gSquelchRSSINarrow = gFrequencyBandInfo.SquelchRSSINarrow[Level];
 }
 

--- a/radio/frequencies.h
+++ b/radio/frequencies.h
@@ -44,10 +44,6 @@ typedef struct __attribute__((packed)) {
 	uint16_t RX_DAC_GainNarrow;
 	uint8_t TxPowerLevelHigh[16];
 	uint8_t TxPowerLevelLow[16];
-	uint8_t SquelchNoiseWide[16];
-	uint8_t SquelchRSSIWide[16];
-	uint8_t SquelchNoiseNarrow[16];
-	uint8_t SquelchRSSINarrow[16];
 } FrequencyBandInfo_t;
 
 extern FrequencyBandInfo_t gFrequencyBandInfo;


### PR DESCRIPTION
The stock squelch code appears to be only partially implemented by Radtel.  It has several issues:

1. It reads in calibration data from storage.  However, this data (at least on my radio) is not actually set.  Those memory addresses are filled with the same base value repeated over and over.
2. It uses modifier tables in the firmware code that make little logical sense.
3. It sets slightly different values for wide vs narrow, but doesn't do it consistently.

Since the 890 and UV-K5 report nearly identical RSSI values from the BK4819, I believe the squelch logic is interchangeable.  This PR replaces the 890 squelch code with tuned code from the K5.  This code is imported from egzumer's build with the calibration/base data exported from 1of11's radio.

On **MY** radio in **MY** home environment this change has made the squelch on the 890 work much better.  In side by side testing with the K5 running tuned firmware, the 890 responds to exactly the same traffic.  

***This change should be tested by others before I commit it.  It has only been tested on my radio.  This changes how squelch works globally.  It can be further tuned if necessary, but needs feedback to do that.***