### PR TITLE
Add K5 squelch settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ TARGET = firmware
 UART_DEBUG			?= 0
 MOTO_STARTUP_TONE		?= 1
 ENABLE_AM_FIX			?= 1
+ENABLE_ALT_SQUELCH		?= 1
 ENABLE_NOAA			?= 1
 ENABLE_SPECTRUM			?= 1
 # Spectrum presets - 1.4 kB
@@ -191,6 +192,9 @@ ifeq ($(MOTO_STARTUP_TONE),1)
 endif
 ifeq ($(ENABLE_AM_FIX),1)
 	CFLAGS += -DENABLE_AM_FIX
+endif
+ifeq ($(ENABLE_ALT_SQUELCH),1)
+	CFLAGS += -DENABLE_ALT_SQUELCH
 endif
 ifeq ($(ENABLE_LTO),1)
 	CFLAGS += -flto=auto

--- a/README.md
+++ b/README.md
@@ -102,11 +102,16 @@ Use [RT-890-SPI-restore-CLI](https://github.com/DualTachyon/radtel-rt-890-spi-re
 
 ### Customizations
 ```
-UART_DEBUG          => UART debug output
-MOTO_STARTUP_TONE   => Moto XPS startup beeps
-ENABLE_AM_FIX       => Experimental port of the great UV-K5 AM fix from OneOfEleven
-ENABLE_LTO          => Link Time Optimization
-ENABLE_NOAA         => NOAA weather channels (always re-set the sidekeys actions from menu after modifying the available actions)
+UART_DEBUG              => UART debug output
+MOTO_STARTUP_TONE       => Moto XPS startup beeps
+ENABLE_AM_FIX           => Experimental port of the great UV-K5 AM fix from OneOfEleven
+ENABLE_ALT_SQUELCH      => Port of optimized UV-K5 squelch system from various firmwares
+ENABLE_NOAA             => NOAA weather channels (always re-set the sidekeys actions from menu after modifying the available actions)
+ENABLE_SPECTRUM         => Spectrum frequency view (assign to a shortcut key to access)
+ENABLE_SPECTRUM_PRESETS => Band presets for Spectrum mode (ENABLE_SPECTRUM required to be enabled)
+ENABLE_FM_RADIO         => FM broadcast radio mode
+ENABLE_LTO              => Link Time Optimization
+ENABLE_OPTIMIZED        => Compiler options to reduce binary size
 ```
 
 ### Build & Flash

--- a/radio/frequencies.c
+++ b/radio/frequencies.c
@@ -24,10 +24,12 @@ uint8_t gCurrentFrequencyBand = 0xFF;
 
 uint8_t gTxPowerLevelHigh = 40;
 uint8_t gTxPowerLevelLow = 20;
+#ifndef ENABLE_ALT_SQUELCH
 uint8_t gSquelchNoiseWide = 40;
 uint8_t gSquelchNoiseNarrow = 40;
 uint8_t gSquelchRSSIWide = 80;
 uint8_t gSquelchRSSINarrow = 85;
+#endif
 
 uint32_t FREQUENCY_GetStep(uint8_t StepSetting)
 {
@@ -95,16 +97,19 @@ void FREQUENCY_SelectBand(uint32_t Frequency)
 	if (Level > 15) {
 		Level = 15;
 	}
-
+#ifndef ENABLE_ALT_SQUELCH
 	gSquelchNoiseWide = gFrequencyBandInfo.SquelchNoiseWide[Level];
 	gSquelchRSSIWide = gFrequencyBandInfo.SquelchRSSIWide[Level];
 	if (Band == BAND_64MHz) {
 		gSquelchNoiseWide += 10;
 		gSquelchRSSIWide -= 10;
 	}
+#endif
 	gTxPowerLevelLow = gFrequencyBandInfo.TxPowerLevelLow[Level];
 	gTxPowerLevelHigh = gFrequencyBandInfo.TxPowerLevelHigh[Level];
+#ifndef ENABLE_ALT_SQUELCH
 	gSquelchNoiseNarrow = gFrequencyBandInfo.SquelchNoiseNarrow[Level];
 	gSquelchRSSINarrow = gFrequencyBandInfo.SquelchRSSINarrow[Level];
+#endif
 }
 

--- a/radio/frequencies.h
+++ b/radio/frequencies.h
@@ -56,10 +56,12 @@ extern uint8_t gCurrentFrequencyBand;
 
 extern uint8_t gTxPowerLevelLow;
 extern uint8_t gTxPowerLevelHigh;
+#ifndef ENABLE_ALT_SQUELCH
 extern uint8_t gSquelchNoiseWide;
 extern uint8_t gSquelchRSSIWide;
 extern uint8_t gSquelchNoiseNarrow;
 extern uint8_t gSquelchRSSINarrow;
+#endif
 
 uint32_t FREQUENCY_GetStep(uint8_t StepSetting);
 void FREQUENCY_SelectBand(uint32_t Frequency);


### PR DESCRIPTION
The squelch tuning in the stock firmware is based on nonsense "calibration" data in the radio memory that was never set by Radtel.  This change adds a Makefile flag to switch from the stock squelch system to the system used in the UV-K5.  The tuning values used for RSSI, noise and glitch base levels are the optimized values used in the 1of11, egzumer and IJV firmwares. 