### PR TITLE
Add ENABLE_SLOWER_RSSI_TIMER

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ ENABLE_REGISTER_EDIT	?= 0
 # Space saving options
 ENABLE_LTO			?= 0
 ENABLE_OPTIMIZED		?= 1
+ENABLE_SLOWER_RSSI_TIMER ?= 1
 
 OBJS =
 # Startup files
@@ -218,6 +219,9 @@ ifeq ($(ENABLE_REGISTER_EDIT), 1)
 endif
 ifeq ($(ENABLE_FM_RADIO), 1)
 	CFLAGS += -DENABLE_FM_RADIO
+endif
+ifeq ($(ENABLE_SLOWER_RSSI_TIMER), 1)
+	CFLAGS += -DENABLE_SLOWER_RSSI_TIMER
 endif
 
 all: $(TARGET)

--- a/task/rssi.c
+++ b/task/rssi.c
@@ -96,7 +96,12 @@ static void CheckRSSI(void)
 		uint16_t RSSI;
 		uint16_t Power;
 
+#ifdef ENABLE_SLOWER_RSSI_TIMER
+		gVoxRssiUpdateTimer = 500;
+#else
 		gVoxRssiUpdateTimer = 100;
+#endif
+
 		RSSI = BK4819_GetRSSI();
 
 		//Valid range is 72 - 330


### PR DESCRIPTION
Cherry-picked from [Joel Calado's repo.](https://github.com/jcalado/RT-890-custom-firmware/commit/eb97ae261845ca510c69076e9ddd0735dda79b8d)

Adds a Makefile option that re-enables (or resets to, more accurately?) the slower update rate of RSSI, twice a second, to reduce screen updates that cause reports of clicking on and around 444-446MHz.