### PR TITLE
Restore frequency or channel on scan exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ Scanning:
 - When scanning is in progress, use the `Freq scanner` key to change the scan list, this action will move to the next non-empty scanlist, or switch to scan all mode if all subsequent lists are empty.  
 - To change the direction of current scan, use the `up`/`down` keys.  
 - To force the scan to resume when the scanner stops on a signal, use the `up`/`down` keys.  
-- Press any key other than `Freq scanner` to stop scanning.  
+- Press any key other than `Freq scanner` or `Up`/`Down` to stop scanning.  
+  - `Exit` key will restore the frequency or channel that was active before scanning started.
+  - `Menu` key will restore the last frequency or channel on wich the scanner stopped.
+  - Any other key will stop the scanner where it is.
 
 ### Spectrum Usage
 Start spectrum by mapping a key (side key or keypad) to the Spectrum action using the main menu.  Spectrum will launch, centered on the frequency from the active VFO/Memory Channel.

--- a/app/radio.c
+++ b/app/radio.c
@@ -270,6 +270,10 @@ void RADIO_Tune(uint8_t Vfo)
 
 void RADIO_StartRX(void)
 {
+	if (gScannerMode) {
+		gScanLastRxFreqOrChannel = gSettings.WorkMode ? gSettings.VfoChNo[gSettings.CurrentVfo]
+													  : gVfoInfo[gSettings.CurrentVfo].Frequency;
+	}
 #ifdef ENABLE_FM_RADIO
 	FM_Disable(FM_MODE_STANDBY);
 #endif

--- a/misc.c
+++ b/misc.c
@@ -48,6 +48,8 @@ uint16_t gNoToneCounter;
 bool gFrequencyReverse;
 bool gManualScanDirection;
 bool gForceScan;
+uint32_t gScanStartFreqOrChannel;
+uint32_t gScanLastRxFreqOrChannel;
 uint8_t gSlot;
 char gString[32];
 char gBigString[40];

--- a/misc.h
+++ b/misc.h
@@ -102,6 +102,8 @@ extern uint16_t gNoToneCounter;
 extern bool gFrequencyReverse;
 extern bool gManualScanDirection;
 extern bool gForceScan;
+extern uint32_t gScanStartFreqOrChannel;	// Frequency or channel to restore after scan
+extern uint32_t gScanLastRxFreqOrChannel;	// Last RX frequency or channel during scan
 extern uint8_t gSlot;
 extern char gString[32];
 extern char gBigString[40];

--- a/task/keyaction.c
+++ b/task/keyaction.c
@@ -218,6 +218,8 @@ void KeypressAction(uint8_t Action) {
 				break;
 
 			case ACTION_SCAN:
+				gScanStartFreqOrChannel = gSettings.WorkMode ? gSettings.VfoChNo[gSettings.CurrentVfo] : gVfoInfo[gSettings.CurrentVfo].Frequency;
+				gScanLastRxFreqOrChannel = gScanStartFreqOrChannel;
 				RADIO_CancelMode();
 				gManualScanDirection = gSettings.ScanDirection;
 				gScannerMode ^= 1;

--- a/task/keys.c
+++ b/task/keys.c
@@ -94,7 +94,7 @@ static void MAIN_KeyHandler(KEY_t Key)
 
 	VOX_Timer = 0;
 	Task_UpdateScreen();
-	if (gScannerMode && Key != KEY_UP && Key != KEY_DOWN) {
+	if (gScannerMode && Key != KEY_UP && Key != KEY_DOWN && Key != KEY_MENU && Key != KEY_EXIT) {
 		SETTINGS_SaveState();
 		return;
 	}
@@ -122,6 +122,20 @@ static void MAIN_KeyHandler(KEY_t Key)
 		break;
 
 	case KEY_MENU:
+		if (gScannerMode) {
+			// stop scanner and restore last RX channel or frequency
+			if (gSettings.WorkMode) {
+				CHANNELS_LoadChannel(gScanLastRxFreqOrChannel, gSettings.CurrentVfo);
+				gSettings.VfoChNo[gSettings.CurrentVfo] = gScanLastRxFreqOrChannel;
+			} else {
+				gVfoInfo[gSettings.CurrentVfo].Frequency = gScanLastRxFreqOrChannel;
+				gVfoState[gSettings.CurrentVfo].RX.Frequency = gScanLastRxFreqOrChannel;
+			}
+			RADIO_Tune(gSettings.CurrentVfo);
+			UI_DrawVfo(gSettings.CurrentVfo);
+			SETTINGS_SaveState();
+			return;
+		}
 		if (gInputBoxWriteIndex == 0) {
 #ifdef ENABLE_FM_RADIO
 			if (gFM_Mode > FM_MODE_STANDBY) {
@@ -194,6 +208,20 @@ static void MAIN_KeyHandler(KEY_t Key)
 		break;
 
 	case KEY_EXIT:
+		if (gScannerMode) {
+			// stop scanner and restore initial channel or frequency
+			if (gSettings.WorkMode) {
+				CHANNELS_LoadChannel(gScanStartFreqOrChannel, gSettings.CurrentVfo);
+				gSettings.VfoChNo[gSettings.CurrentVfo] = gScanStartFreqOrChannel;
+			} else {
+				gVfoInfo[gSettings.CurrentVfo].Frequency = gScanStartFreqOrChannel;
+				gVfoState[gSettings.CurrentVfo].RX.Frequency = gScanStartFreqOrChannel;
+			}
+			RADIO_Tune(gSettings.CurrentVfo);
+			UI_DrawVfo(gSettings.CurrentVfo);
+			SETTINGS_SaveState();
+			return;
+		}
 		if (gInputBoxWriteIndex) {
 #ifdef ENABLE_FM_RADIO
 			if (gFM_Mode == FM_MODE_PLAY) {
@@ -394,11 +422,11 @@ static void HandlerLong(KEY_t Key)
 			case KEY_9:
 				KeypressAction(gExtendedSettings.KeyShortcut[Key]);
 				break;
-			
+
 			case KEY_STAR:
 				KeypressAction(gExtendedSettings.KeyShortcut[10]);
 				break;
-			
+
 			case KEY_HASH:
 				KeypressAction(gExtendedSettings.KeyShortcut[11]);
 				break;
@@ -406,7 +434,7 @@ static void HandlerLong(KEY_t Key)
 			case KEY_MENU:
 				KeypressAction(gExtendedSettings.KeyShortcut[12]);
 				break;
-			
+
 			case KEY_EXIT:
 				KeypressAction(gExtendedSettings.KeyShortcut[13]);
 				break;


### PR DESCRIPTION
Leaves scanner with `exit` restores initial freq/channel.
Leaves scanner with `menu` restores last RX freq/channel.