### PR TITLE
Make the TX / RX meters optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,23 @@ MOTO_STARTUP_TONE		?= 1
 ENABLE_AM_FIX			?= 1
 ENABLE_ALT_SQUELCH		?= 1
 ENABLE_NOAA			?= 1
+ENABLE_RX_BAR			?= 1
+ENABLE_TX_BAR			?= 1
+ENABLE_SLOWER_RSSI_TIMER	?= 1
 ENABLE_SPECTRUM			?= 1
+
 # Spectrum presets - 1.4 kB
 ENABLE_SPECTRUM_PRESETS		?= 1
 # FM radio = 2.6 kB
 ENABLE_FM_RADIO			?= 1
 # Register Editor = .5 kB
 ENABLE_REGISTER_EDIT		?= 0
+# Scanlist membership display - 252 B
+ENABLE_SCANLIST_DISPLAY		?= 1
 # Space saving options
 ENABLE_LTO			?= 0
 ENABLE_OPTIMIZED		?= 1
-ENABLE_SLOWER_RSSI_TIMER	?= 1
-# Scanlist membership display - 252 B
-ENABLE_SCANLIST_DISPLAY		?= 1
+
 
 OBJS =
 # Startup files
@@ -224,6 +228,12 @@ ifeq ($(ENABLE_FM_RADIO), 1)
 endif
 ifeq ($(ENABLE_SLOWER_RSSI_TIMER), 1)
 	CFLAGS += -DENABLE_SLOWER_RSSI_TIMER
+endif
+ifeq ($(ENABLE_RX_BAR), 1)
+	CFLAGS += -DENABLE_RX_BAR
+endif
+ifeq ($(ENABLE_TX_BAR), 1)
+	CFLAGS += -DENABLE_TX_BAR
 endif
 ifeq ($(ENABLE_SCANLIST_DISPLAY), 1)
 	CFLAGS += -DENABLE_SCANLIST_DISPLAY

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ ENABLE_FM_RADIO          => FM broadcast radio mode
 ENABLE_LTO               => Link Time Optimization
 ENABLE_OPTIMIZED         => Compiler options to reduce binary size
 ENABLE_SLOWER_RSSI_TIMER => Slower update rate of RSSI to reduce screen updates that cause reports of clicking around 444-446MHz
+ENABLE_RX_BAR            => Display RSSI level bar when RX
+ENABLE_TX_BAR            => Display vox level bar when TX
 ENABLE_SCANLIST_DISPLAY  => Display scanlists membership instead of empty RSSI grid in channel mode when radio not RX/TX
 ```
 

--- a/radio/channels.c
+++ b/radio/channels.c
@@ -33,7 +33,9 @@
 #endif
 #include "ui/vfo.h"
 #ifdef ENABLE_SCANLIST_DISPLAY
+#if defined(ENABLE_RX_BAR) || defined(ENABLE_TX_BAR)
 #include "ui/gfx.h"
+#endif
 #endif
 
 static const ChannelInfo_t VfoTemplate[2] = {
@@ -654,10 +656,13 @@ void CHANNELS_LoadVfoMode(void)
 void CHANNELS_LoadWorkMode(void)
 {
 #ifdef ENABLE_SCANLIST_DISPLAY
+#if defined(ENABLE_RX_BAR) || defined(ENABLE_TX_BAR)
+
 	DISPLAY_Fill(20, 127, 43 - (gSettings.CurrentVfo * 41), 49 - (gSettings.CurrentVfo * 41), COLOR_BACKGROUND);
 	if (gSettings.DualDisplay) {
 		DISPLAY_Fill(20, 127, 43 - ((1 - gSettings.CurrentVfo) * 41), 49 - ((1 - gSettings.CurrentVfo) * 41), COLOR_BACKGROUND);
 	}
+#endif
 #endif
 	if (CHANNELS_LoadChannel(gSettings.VfoChNo[0], 0)) {
 		gSettings.VfoChNo[0] = CHANNELS_GetChannelUp(gSettings.VfoChNo[0], 0);

--- a/task/rssi.c
+++ b/task/rssi.c
@@ -112,12 +112,17 @@ static void CheckRSSI(void)
 		} else {
 			Power = ((RSSI-72)*100)/258;
 		}
-		
+#ifdef ENABLE_RX_BAR	
 		UI_DrawBar(Power, gCurrentVfo);
+#endif		
 		ConvertRssiToDbm(RSSI);
+#ifdef ENABLE_RX_BAR		
 		UI_DrawRxDBM(gCurrentVfo, false);
+#endif
 		ConvertRssiToSmeter(RSSI);
+#ifdef ENABLE_RX_BAR		
 		UI_DrawRxSmeter(!gCurrentVfo, false);
+#endif
 		gCurrentRssi[gCurrentVfo] = Power;
 	}
 }

--- a/task/vox.c
+++ b/task/vox.c
@@ -70,7 +70,9 @@ void VOX_Update(void)
 		if (Vox > 5000) {
 			Vox = 5000;
 		}
+#ifdef ENABLE_TX_BAR		
 		UI_DrawBar(Vox / 50, gSettings.CurrentVfo);
+#endif
 	}
 }
 

--- a/ui/helper.c
+++ b/ui/helper.c
@@ -816,8 +816,11 @@ void UI_DrawSomething(void)
 		UI_DrawVoltage(!gSettings.CurrentVfo);
 		UI_DrawVfo(gSettings.CurrentVfo);
 	} else {
+
 #ifdef ENABLE_SCANLIST_DISPLAY
+#if defined(ENABLE_RX_BAR) || defined(ENABLE_TX_BAR)
 		DISPLAY_Fill(20, 127, 43 - Y, 49 - Y, COLOR_BACKGROUND);
+#endif
 #endif
 		UI_DrawVfo(gCurrentVfo);
 		if (gSettings.CurrentVfo == gCurrentVfo && gInputBoxWriteIndex) {

--- a/ui/vfo.c
+++ b/ui/vfo.c
@@ -42,18 +42,24 @@ void UI_DrawVfo(uint8_t Vfo)
 		UI_DrawScanLists(Vfo);
 	} else {
 #endif
+#if defined ENABLE_RX_BAR || defined ENABLE_TX_BAR
 		UI_DrawVfoFrame(Vfo);
+#endif
 #ifdef ENABLE_SCANLIST_DISPLAY
 	}
 #endif
 
 	if (Vfo == gCurrentVfo) {
 		if (gRadioMode == RADIO_MODE_RX) {
+#ifdef ENABLE_RX_BAR
 			UI_DrawRX(Vfo);
+#endif
 			UI_DrawExtra(2, gVfoState[Vfo].gModulationType, Vfo);
 			gColorForeground = COLOR_BLUE;
 		} else if (gRadioMode == RADIO_MODE_TX) {
+#ifdef ENABLE_RX_BAR
 			UI_DrawRX(Vfo);
+#endif
 			UI_DrawExtra(1, gVfoState[Vfo].gModulationType, Vfo);
 			gColorForeground = COLOR_RED;
 		} else {


### PR DESCRIPTION
- Reorganizes makefile flags alphabetically, 
- Disabling either keeps the vfo frame rectangles being drawn.
- Disabling both also disables the vfo frame making for, IMHO, a cleaner look:

![image](https://github.com/OEFW-community/RT-890-custom-firmware/assets/26873/2fbdb369-f7a5-43ab-be30-cc06b944b78f)
