### PR TITLE
Update `checkout` and `upload-artifact` actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
         release: '10.3-2021.10'
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Submodules
       run: git submodule update --init --recursive --depth 1
@@ -24,7 +24,7 @@ jobs:
       run:  arm-none-eabi-size firmware
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: firmware
         path: firmware*.bin

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       run:  arm-none-eabi-size firmware
 
     - name: 'Upload Artifact'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: firmware
         path: firmware.bin


### PR DESCRIPTION
To upgrade deprecated node 16 to 20